### PR TITLE
Use token passed to workflow

### DIFF
--- a/.github/workflows/lawa-js-ci.yml
+++ b/.github/workflows/lawa-js-ci.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set auth token
         run: echo "//npm.pkg.github.com/:_authToken=${NODE_AUTH_TOKEN}" >> .npmrc
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.github-token }}
       - name: Install yarn dependencies
         run: |
           cd ${{ inputs.yarn-cwd }}


### PR DESCRIPTION
The token is passed in externally and the workflow has no access to repo envs