### PR TITLE
[TSI-1995] Add bundle config

### DIFF
--- a/.github/workflows/lawa-elixir-ci.yml
+++ b/.github/workflows/lawa-elixir-ci.yml
@@ -50,7 +50,6 @@ jobs:
           ImageOS: ubuntu20
         with:
           ruby-version: ${{ inputs.ruby-version }}
-          bundler-cache: true
       - name: Install compatible bundler version
         run: gem install bundler:${{ inputs.ruby-bundler-version }}
       - name: Install lawa

--- a/.github/workflows/lawa-js-ci.yml
+++ b/.github/workflows/lawa-js-ci.yml
@@ -26,11 +26,15 @@ on:
     secrets:
       github-token:
         required: true
+      sidekiq-enterprise-key:
+        required: false
 
 jobs:
   lawa:
     name: lawa
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.sidekiq-enterprise-key }}
     steps:
       - name: Checkout app
         uses: actions/checkout@v1
@@ -63,7 +67,6 @@ jobs:
         with:
           ruby-version: ${{ inputs.ruby-version }}
           bundler-cache: true
-          cache-version: 1
         env:
           BUNDLE_GITHUB__COM: x-access-token:${{ secrets.github-token }}
       - name: Install compatible bundler version

--- a/.github/workflows/lawa-js-ci.yml
+++ b/.github/workflows/lawa-js-ci.yml
@@ -33,6 +33,8 @@ jobs:
   lawa:
     name: lawa
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.sidekiq-enterprise-config }}
     steps:
       - name: Checkout app
         uses: actions/checkout@v1
@@ -60,14 +62,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.github-token }}
           GITHUB_ACCESS_TOKEN: ${{ secrets.github-token }}
           NODE_AUTH_TOKEN: ${{ secrets.github-token }}
-      - name: Set bundle config
-        run: |
-          if [ -n "${{ secrets.sidekiq-enterprise-config }}" ]; then
-            echo "Setting Sidekiq Enterprise config"
-            export BUNDLE_ENTERPRISE__CONTRIBSYS__COM=${{ secrets.sidekiq-enterprise-config }}
-          else
-            echo "Sidekiq Enterprise config not supplied"
-          fi
       - name: Set up Ruby
         uses: ruby/setup-ruby@c7079efafd956afb5d823e8999c2506e1053aefa
         with:

--- a/.github/workflows/lawa-js-ci.yml
+++ b/.github/workflows/lawa-js-ci.yml
@@ -67,7 +67,6 @@ jobs:
         with:
           ruby-version: ${{ inputs.ruby-version }}
           bundler-cache: true
-          cache-version: 1
         env:
           BUNDLE_GITHUB__COM: x-access-token:${{ secrets.github-token }}
       - name: Install compatible bundler version

--- a/.github/workflows/lawa-js-ci.yml
+++ b/.github/workflows/lawa-js-ci.yml
@@ -26,6 +26,8 @@ on:
     secrets:
       github-token:
         required: true
+      sidekiq-enterprise-config:
+        required: false
 
 jobs:
   lawa:
@@ -58,6 +60,14 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.github-token }}
           GITHUB_ACCESS_TOKEN: ${{ secrets.github-token }}
           NODE_AUTH_TOKEN: ${{ secrets.github-token }}
+      - name: Set bundle config
+        run: |
+          if [ -n "${{ secrets.sidekiq-enterprise-config }}" ]; then
+            echo "Setting Sidekiq Enterprise config"
+            export BUNDLE_ENTERPRISE__CONTRIBSYS__COM=${{ secrets.sidekiq-enterprise-config }}
+          else
+            echo "Sidekiq Enterprise config not supplied"
+          fi
       - name: Set up Ruby
         uses: ruby/setup-ruby@c7079efafd956afb5d823e8999c2506e1053aefa
         with:

--- a/.github/workflows/lawa-js-ci.yml
+++ b/.github/workflows/lawa-js-ci.yml
@@ -26,15 +26,11 @@ on:
     secrets:
       github-token:
         required: true
-      sidekiq-enterprise-config:
-        required: false
 
 jobs:
   lawa:
     name: lawa
     runs-on: ubuntu-latest
-    env:
-      BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.sidekiq-enterprise-config }}
     steps:
       - name: Checkout app
         uses: actions/checkout@v1

--- a/.github/workflows/lawa-js-ci.yml
+++ b/.github/workflows/lawa-js-ci.yml
@@ -26,8 +26,6 @@ on:
     secrets:
       github-token:
         required: true
-      sidekiq-enterprise-key:
-        required: false
 
 jobs:
   lawa:

--- a/.github/workflows/lawa-js-ci.yml
+++ b/.github/workflows/lawa-js-ci.yml
@@ -33,8 +33,6 @@ jobs:
   lawa:
     name: lawa
     runs-on: ubuntu-latest
-    env:
-      BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.sidekiq-enterprise-key }}
     steps:
       - name: Checkout app
         uses: actions/checkout@v1
@@ -66,7 +64,6 @@ jobs:
         uses: ruby/setup-ruby@c7079efafd956afb5d823e8999c2506e1053aefa
         with:
           ruby-version: ${{ inputs.ruby-version }}
-          bundler-cache: true
         env:
           BUNDLE_GITHUB__COM: x-access-token:${{ secrets.github-token }}
       - name: Install compatible bundler version

--- a/.github/workflows/lawa-js-ci.yml
+++ b/.github/workflows/lawa-js-ci.yml
@@ -67,6 +67,7 @@ jobs:
         with:
           ruby-version: ${{ inputs.ruby-version }}
           bundler-cache: true
+          cache-version: 1
         env:
           BUNDLE_GITHUB__COM: x-access-token:${{ secrets.github-token }}
       - name: Install compatible bundler version

--- a/.github/workflows/lawa-js-ci.yml
+++ b/.github/workflows/lawa-js-ci.yml
@@ -63,6 +63,7 @@ jobs:
         with:
           ruby-version: ${{ inputs.ruby-version }}
           bundler-cache: true
+          cache-version: 1
         env:
           BUNDLE_GITHUB__COM: x-access-token:${{ secrets.github-token }}
       - name: Install compatible bundler version

--- a/.github/workflows/lawa-ruby-ci.yml
+++ b/.github/workflows/lawa-ruby-ci.yml
@@ -18,15 +18,11 @@ on:
     secrets:
       github-token:
         required: true
-      sidekiq-enterprise-config:
-        required: false
 
 jobs:
   lawa:
     name: lawa
     runs-on: ubuntu-latest
-    env:
-      BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.sidekiq-enterprise-config }}
     steps:
       - name: Checkout app
         uses: actions/checkout@v3

--- a/.github/workflows/lawa-ruby-ci.yml
+++ b/.github/workflows/lawa-ruby-ci.yml
@@ -25,8 +25,6 @@ jobs:
   lawa:
     name: lawa
     runs-on: ubuntu-latest
-    env:
-      BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.sidekiq-enterprise-key }}
     steps:
       - name: Checkout app
         uses: actions/checkout@v3
@@ -34,7 +32,6 @@ jobs:
         uses: ruby/setup-ruby@9669f3ee51dc3f4eda8447ab696b3ab19a90d14b # pin@v1.144.0
         with:
           ruby-version: ${{ inputs.ruby-version }}
-          bundler-cache: true
         env:
           BUNDLE_GITHUB__COM: x-access-token:${{ secrets.github-token }}
       - name: Install compatible bundler version

--- a/.github/workflows/lawa-ruby-ci.yml
+++ b/.github/workflows/lawa-ruby-ci.yml
@@ -18,6 +18,8 @@ on:
     secrets:
       github-token:
         required: true
+      sidekiq-enterprise-config:
+        required: false
 
 jobs:
   lawa:
@@ -26,6 +28,14 @@ jobs:
     steps:
       - name: Checkout app
         uses: actions/checkout@v3
+      - name: Set bundle config
+        run: |
+          if [ -n "${{ secrets.sidekiq-enterprise-config }}" ]; then
+            echo "Setting Sidekiq Enterprise config"
+            export BUNDLE_ENTERPRISE__CONTRIBSYS__COM=${{ secrets.sidekiq-enterprise-config }}
+          else
+            echo "Sidekiq Enterprise config not supplied"
+          fi
       - name: Set up Ruby
         uses: ruby/setup-ruby@9669f3ee51dc3f4eda8447ab696b3ab19a90d14b # pin@v1.144.0
         with:

--- a/.github/workflows/lawa-ruby-ci.yml
+++ b/.github/workflows/lawa-ruby-ci.yml
@@ -18,8 +18,6 @@ on:
     secrets:
       github-token:
         required: true
-      sidekiq-enterprise-key:
-        required: false
 
 jobs:
   lawa:

--- a/.github/workflows/lawa-ruby-ci.yml
+++ b/.github/workflows/lawa-ruby-ci.yml
@@ -35,7 +35,6 @@ jobs:
         with:
           ruby-version: ${{ inputs.ruby-version }}
           bundler-cache: true
-          cache-version: 1
         env:
           BUNDLE_GITHUB__COM: x-access-token:${{ secrets.github-token }}
       - name: Install compatible bundler version

--- a/.github/workflows/lawa-ruby-ci.yml
+++ b/.github/workflows/lawa-ruby-ci.yml
@@ -31,6 +31,7 @@ jobs:
         with:
           ruby-version: ${{ inputs.ruby-version }}
           bundler-cache: true
+          cache-version: 1
         env:
           BUNDLE_GITHUB__COM: x-access-token:${{ secrets.github-token }}
       - name: Install compatible bundler version

--- a/.github/workflows/lawa-ruby-ci.yml
+++ b/.github/workflows/lawa-ruby-ci.yml
@@ -35,6 +35,7 @@ jobs:
         with:
           ruby-version: ${{ inputs.ruby-version }}
           bundler-cache: true
+          cache-version: 1
         env:
           BUNDLE_GITHUB__COM: x-access-token:${{ secrets.github-token }}
       - name: Install compatible bundler version

--- a/.github/workflows/lawa-ruby-ci.yml
+++ b/.github/workflows/lawa-ruby-ci.yml
@@ -25,17 +25,11 @@ jobs:
   lawa:
     name: lawa
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.sidekiq-enterprise-config }}
     steps:
       - name: Checkout app
         uses: actions/checkout@v3
-      - name: Set bundle config
-        run: |
-          if [ -n "${{ secrets.sidekiq-enterprise-config }}" ]; then
-            echo "Setting Sidekiq Enterprise config"
-            export BUNDLE_ENTERPRISE__CONTRIBSYS__COM=${{ secrets.sidekiq-enterprise-config }}
-          else
-            echo "Sidekiq Enterprise config not supplied"
-          fi
       - name: Set up Ruby
         uses: ruby/setup-ruby@9669f3ee51dc3f4eda8447ab696b3ab19a90d14b # pin@v1.144.0
         with:

--- a/.github/workflows/lawa-ruby-ci.yml
+++ b/.github/workflows/lawa-ruby-ci.yml
@@ -18,11 +18,15 @@ on:
     secrets:
       github-token:
         required: true
+      sidekiq-enterprise-key:
+        required: false
 
 jobs:
   lawa:
     name: lawa
     runs-on: ubuntu-latest
+    env:
+      BUNDLE_ENTERPRISE__CONTRIBSYS__COM: ${{ secrets.sidekiq-enterprise-key }}
     steps:
       - name: Checkout app
         uses: actions/checkout@v3
@@ -31,7 +35,6 @@ jobs:
         with:
           ruby-version: ${{ inputs.ruby-version }}
           bundler-cache: true
-          cache-version: 1
         env:
           BUNDLE_GITHUB__COM: x-access-token:${{ secrets.github-token }}
       - name: Install compatible bundler version


### PR DESCRIPTION
Sidekiq enterprise has been added to phrase repo. Adding sidekiq enterprise credentials to avoid failure when license check runs bundle and attempts to install sidekiq enterprise version without credentials. 

**Update**

Later, it was realised all the checks for ruby, elixir and JS are installing all of the gems listed in the gemfile because of the option `bundler-cache: true`. Which forced us to specify sidekiq enterprise key for all 3 workflows. 
After internal discussion, we came to the conclusion to see if these checks will work without installation of all the gems.


Linked PR: https://github.com/phrase/phrase/pull/11742