### PR TITLE
Disable persist credentials

### DIFF
--- a/.github/workflows/lawa-js-ci.yml
+++ b/.github/workflows/lawa-js-ci.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: Checkout app
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Set up node
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Without this configuration the JS lawa action fails to fetch packages from internal repositories since updating to checkout v4. I guess it's setting the wrong token initially somehow and is not using `github-token`