### PR TITLE
Ruby lawa action using unset deployment

### DIFF
--- a/lawa-ruby-ci/action.yml
+++ b/lawa-ruby-ci/action.yml
@@ -20,7 +20,7 @@ runs:
       shell: bash
       run: |
         cd ${{ inputs.working-directory }}
-        bundle config set frozen false
+        bundle config unset deployment
         bundle add -g development lawa --github "phrase/lawa"
         bundle lock --add-platform x86_64-linux
         bundle exec lawa --enabled-package-managers bundler --decisions-file=${{ inputs.decisions-file }}


### PR DESCRIPTION
After trying to use this action in xtm_sync repo, I was getting the following error: https://github.com/phrase/xtm_sync/actions/runs/15138901866/job/42557393614

Using `bundle config unset deployment` enabled the check to be performed

Tried the same change with `phrase/phrase` too, and the check still works.