### PR TITLE
Use latest runner for Elixir

### DIFF
--- a/.github/workflows/lawa-elixir-ci.yml
+++ b/.github/workflows/lawa-elixir-ci.yml
@@ -32,12 +32,7 @@ jobs:
     name: lawa
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl1.0/libssl1.0.0_1.0.2n-1ubuntu5_amd64.deb
-          sudo apt-get install ./libssl1.0.0_1.0.2n-1ubuntu5_amd64.deb
       - uses: erlef/setup-beam@v1
-        env:
-          ImageOS: ubuntu20
         with:
           otp-version: ${{ inputs.otp-version }}
           elixir-version: ${{ inputs.elixir-version }}
@@ -46,8 +41,6 @@ jobs:
       - run: mix deps.get
       - name: Set up Ruby
         uses: ruby/setup-ruby@e851ebd3adcc861aa9e9763c26a9025811f77cd9
-        env:
-          ImageOS: ubuntu20
         with:
           ruby-version: ${{ inputs.ruby-version }}
       - name: Install compatible bundler version


### PR DESCRIPTION
- libssl1 should no longer be needed started with OTP 26
- Remove old runner image